### PR TITLE
Allow author names to contain email addresses

### DIFF
--- a/.githooks/license-maintainer/license.pm
+++ b/.githooks/license-maintainer/license.pm
@@ -73,7 +73,7 @@ sub regexpify_license {
 	    $special = '(?<'.$YEARS_CAPTURE_GROUP.'>'.$year_or_year_range_regexp.'(?:\s*,\s*'.$year_or_year_range_regexp.')*)';
 	} elsif ($special eq 'AUTHORS') {
 	    # accept any sensibly formatted set of authors, ignoring whitespace
-	    my $author_regexp = '\w[^\r\n,]*\w';
+	    my $author_regexp = '\w[^\r\n,]*[\w>]';
 	    $special = '(?<'.$AUTHORS_CAPTURE_GROUP.'>'.$author_regexp.'(?:\s*,\s*'.$author_regexp.')*)';
 	} elsif(length($special)) {
 	    $special = '\s+'; # instead of exact sequence of whitespace characters accept any amount of whitespace


### PR DESCRIPTION
Change the author regexp to allow author "names" to end with a ">"
character thus permitting such names to include authors' email address
marked in the common way of surrounding it with pointy brackets.

Fixes #5 