### PR TITLE
Adapted install script for compatibility with the macos ln command (hooks-only branch)

### DIFF
--- a/.githooks/license-maintainer/install
+++ b/.githooks/license-maintainer/install
@@ -26,10 +26,16 @@ fi
 
 cd "$(dirname "$0")/../.."
 
+linkcmd="ln -snv"
+
+if [[ $OSTYPE != "darwin"* ]] ; then
+    linkcmd="$linkcmd --backup=numbered"
+fi
+
 for i in pre-commit ; do
     oldlink="$(readlink .git/hooks/${i} ||:)"
     newlink="../../.githooks/license-maintainer/${i}"
     if [ "$newlink" != "$oldlink" ]; then
-	ln -snv --backup=numbered "${newlink}" .git/hooks/
+	$linkcmd "${newlink}" .git/hooks/
     fi
 done


### PR DESCRIPTION
The `ln` command on MacOS lacks a `--backup` flag, so the script fails. This commit modifies the install script to detect the operating system, and run the command to create the symlink without the `--backup` flag if it is MacOS.

I modified this for use in one of my projects, and figured I'd make it available to you for the base repository, if you are interested. Thanks for the great script!